### PR TITLE
Bugfix/external link in preview

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -79,7 +79,7 @@ export async function readPreview(fileEntity: FileEntity) {
   }
 
   const updatedContent = content.replace(/^(.*\n)?---[\s\S]*?---\n?/m, "");
-  const lines = updatedContent.split(/\n/);
+  const lines = shortenExternalLinkInPreview(updatedContent).split(/\n/);
   return lines
     .filter((it: string) => {
       return it.match(/\S/) && !it.match(/^#/) && !it.match(/^https?:\/\//);
@@ -99,4 +99,10 @@ export function getThumbnailUrlFromIframeUrl(iframeUrl: string): string | null {
   }
 
   return null;
+}
+
+export function shortenExternalLinkInPreview(content: string): string {
+  // ex. [ABC](https://www.example.com/) -> [ABC](...)
+  const regex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  return content.replace(regex, "[$1](...)");
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -102,7 +102,6 @@ export function getThumbnailUrlFromIframeUrl(iframeUrl: string): string | null {
 }
 
 export function shortenExternalLinkInPreview(content: string): string {
-  // ex. [ABC](https://www.example.com/) -> [ABC](...)
   const regex = /\[([^\]]+)\]\(([^)]+)\)/g;
   return content.replace(regex, "[$1](...)");
 }


### PR DESCRIPTION
## 変更点
2ホップリンクなどのプレビュー内にある外部リンクを短く表示するようにした
例) \[ABCD](https://www.example.com/) -> \[ABCD](...)

## 理由
- リンクのURLは長いことが多く、プレビューのほとんどを占有してしまうことが多い
- \[xxx](yyy)形式で書いてる場合、URLが何かはあまり重要でない

## コメント
便利にこちらのプラグインを使わせていただいています。自分的に便利だと思う変更を追加してみましたので、ご一考いただけると幸いです。(issueを出せば良かったのかもしれませんが笑)