### PR TITLE
Frontmatter設定フィールドとタイトル取得関数を追加しました

### DIFF
--- a/src/getTitle.ts
+++ b/src/getTitle.ts
@@ -1,0 +1,28 @@
+import { FileEntity } from "./model/FileEntity";
+import { removeBlockReference } from "./utils";
+
+export async function getTitle(fileEntity: FileEntity) {
+    console.log("in getTitle Func!"); // for development
+    console.log(fileEntity); // for development
+    console.log(this); // for development
+    const linkText = removeBlockReference(fileEntity.linkText);
+    console.log(linkText); // for development
+
+    if (!this.settings.frontmatterPropertyKeyAsTitle) return linkText;
+
+    const file = this.app.metadataCache.getFirstLinkpathDest(
+    linkText,
+    fileEntity.sourcePath
+    );
+
+    console.log(file); // for development
+    if (file == null) return linkText;
+    if (!file.extension?.match(/^(md|markdown)$/)) return linkText;
+
+    const metadata = this.app.metadataCache.getFileCache(file)
+
+    if(!metadata.frontmatter?[this.settings.frontmatterPropertyKeyAsTitle]) return linkText;
+
+    const title = metadata.frontmatter[this.settings.frontmatterPropertyKeyAsTitle];
+    return title;
+}

--- a/src/getTitle.ts
+++ b/src/getTitle.ts
@@ -9,7 +9,6 @@ export async function getTitle(fileEntity: FileEntity) {
     console.log(linkText); // for development
 
     if (!this.settings.frontmatterPropertyKeyAsTitle) return linkText;
-
     const file = this.app.metadataCache.getFirstLinkpathDest(
     linkText,
     fileEntity.sourcePath
@@ -21,7 +20,7 @@ export async function getTitle(fileEntity: FileEntity) {
 
     const metadata = this.app.metadataCache.getFileCache(file)
 
-    if(!metadata.frontmatter?[this.settings.frontmatterPropertyKeyAsTitle]) return linkText;
+    if(!metadata.frontmatter || !metadata.frontmatter[this.settings.frontmatterPropertyKeyAsTitle]) return linkText;
 
     const title = metadata.frontmatter[this.settings.frontmatterPropertyKeyAsTitle];
     return title;

--- a/src/getTitle.ts
+++ b/src/getTitle.ts
@@ -2,11 +2,7 @@ import { FileEntity } from "./model/FileEntity";
 import { removeBlockReference } from "./utils";
 
 export async function getTitle(fileEntity: FileEntity) {
-    console.log("in getTitle Func!"); // for development
-    console.log(fileEntity); // for development
-    console.log(this); // for development
     const linkText = removeBlockReference(fileEntity.linkText);
-    console.log(linkText); // for development
 
     if (!this.settings.frontmatterPropertyKeyAsTitle) return linkText;
     const file = this.app.metadataCache.getFirstLinkpathDest(
@@ -14,7 +10,6 @@ export async function getTitle(fileEntity: FileEntity) {
     fileEntity.sourcePath
     );
 
-    console.log(file); // for development
     if (file == null) return linkText;
     if (!file.extension?.match(/^(md|markdown)$/)) return linkText;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -171,12 +171,6 @@ export default class TwohopLinksPlugin extends Plugin {
   }
 
   async renderTwohopLinks(isForceUpdate: boolean): Promise<void> {
-    // for development start
-    console.log("--- start ---");
-    let title = await getTitle.call(this, new FileEntity("folder1/無題のファイル 1.md", "test file 3"));
-    console.log(`title: ${title}`);
-    console.log("--- end ---");
-    // for development end
     if (this.settings.showTwoHopLinksInSeparatePane) {
       return;
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -247,6 +247,7 @@ export default class TwohopLinksPlugin extends Plugin {
         frontmatterKeyLinksList={frontmatterKeyLinksList}
         onClick={this.openFile.bind(this)}
         getPreview={readPreview.bind(this)}
+        getTitle={getTitle.bind(this)}
         app={this.app}
         showForwardConnectedLinks={showForwardConnectedLinks}
         showBackwardConnectedLinks={showBackwardConnectedLinks}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import {
 } from "./settings/TwohopSettingTab";
 import { SeparatePaneView } from "./ui/SeparatePaneView";
 import { readPreview } from "./preview";
+import { getTitle } from "./getTitle";
 import { loadSettings } from "./settings/index";
 import { Links } from "./links";
 
@@ -99,7 +100,7 @@ export default class TwohopLinksPlugin extends Plugin {
     );
   }
 
-  async updateTwoHopLinksView() {
+  async updateTwoHopLinksView() {   
     if (this.isTwoHopLinksViewOpen()) {
       this.app.workspace.detachLeavesOfType("TwoHopLinksView");
     }
@@ -170,6 +171,12 @@ export default class TwohopLinksPlugin extends Plugin {
   }
 
   async renderTwohopLinks(isForceUpdate: boolean): Promise<void> {
+    // for development start
+    console.log("--- start ---");
+    let title = await getTitle.call(this, new FileEntity("folder1/無題のファイル 1.md", "test file 3"));
+    console.log(`title: ${title}`);
+    console.log("--- end ---");
+    // for development end
     if (this.settings.showTwoHopLinksInSeparatePane) {
       return;
     }

--- a/src/settings/TwohopSettingTab.ts
+++ b/src/settings/TwohopSettingTab.ts
@@ -135,7 +135,7 @@ export class TwohopSettingTab extends PluginSettingTab {
       "createFilesForMultiLinked"
     );
     this.createTextSettingStr(
-      "Set frontmatte property key as title",
+      "Set frontmatter property key as title",
       "Set the property key of the frontmatter to be used as the title to be displayed.",
       "frontmatterPropertyKeyAsTitle"
     );

--- a/src/settings/TwohopSettingTab.ts
+++ b/src/settings/TwohopSettingTab.ts
@@ -20,6 +20,7 @@ export interface TwohopPluginSettings {
   excludeTags: string[];
   panePositionIsRight: boolean;
   createFilesForMultiLinked: boolean;
+  frontmatterPropertyKeyAsTitle: string;
   frontmatterKeys: string[];
   [key: string]: boolean | string | string[] | number | undefined;
 }
@@ -133,6 +134,11 @@ export class TwohopSettingTab extends PluginSettingTab {
       "Create new files for links that are connected to more than one other file.",
       "createFilesForMultiLinked"
     );
+    this.createTextSettingStr(
+      "Set frontmatte property key as title",
+      "Set the property key of the frontmatter to be used as the title to be displayed.",
+      "frontmatterPropertyKeyAsTitle"
+    );
   }
 
   createToggleSetting(
@@ -216,6 +222,24 @@ export class TwohopSettingTab extends PluginSettingTab {
           this.plugin.settings[key] = Number(
             (event.target as HTMLInputElement).value
           );
+          await saveSettings(this.plugin);
+          await this.plugin.updateTwoHopLinksView();
+        });
+      });
+  }
+
+  createTextSettingStr(
+    name: string,
+    desc: string,
+    key: keyof TwohopPluginSettings
+  ) {
+    new Setting(this.containerEl)
+      .setName(name)
+      .setDesc(desc)
+      .addText((text) => {
+        text.setValue(this.plugin.settings[key] as string);
+        text.inputEl.addEventListener("blur", async (event) => {
+          this.plugin.settings[key] = (event.target as HTMLInputElement).value;
           await saveSettings(this.plugin);
           await this.plugin.updateTwoHopLinksView();
         });

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -19,7 +19,7 @@ export const DEFAULT_SETTINGS: TwohopPluginSettings = {
   excludeTags: [],
   panePositionIsRight: false,
   createFilesForMultiLinked: false,
-  frontmatterPropertyKeyAsTitle: "title",
+  frontmatterPropertyKeyAsTitle: "",
   frontmatterKeys: [],
 };
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -19,6 +19,7 @@ export const DEFAULT_SETTINGS: TwohopPluginSettings = {
   excludeTags: [],
   panePositionIsRight: false,
   createFilesForMultiLinked: false,
+  frontmatterPropertyKeyAsTitle: "title",
   frontmatterKeys: [],
 };
 

--- a/src/ui/ConnectedLinksView.tsx
+++ b/src/ui/ConnectedLinksView.tsx
@@ -8,6 +8,7 @@ interface ConnectedLinksViewProps {
   displayedBoxCount: number;
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   onLoadMore: () => void;
   title: string;
   className: string;
@@ -56,6 +57,7 @@ export default class ConnectedLinksView extends React.Component<ConnectedLinksVi
                   key={it.key()}
                   onClick={this.props.onClick}
                   getPreview={this.props.getPreview}
+                  getTitle={this.props.getTitle}
                   app={this.props.app}
                 />
               );

--- a/src/ui/LinkView.tsx
+++ b/src/ui/LinkView.tsx
@@ -14,6 +14,7 @@ interface LinkViewProps {
 
 interface LinkViewState {
   preview: string;
+  title: string;
   mouseDown: boolean;
   dragging: boolean;
   touchStart: number;
@@ -31,6 +32,7 @@ export default class LinkView
     super(props);
     this.state = {
       preview: null,
+      title: null,
       mouseDown: false,
       dragging: false,
       touchStart: 0,
@@ -44,9 +46,17 @@ export default class LinkView
       this.props.fileEntity,
       this.abortController.signal
     );
+    const title = await this.props.getTitle(
+      this.props.fileEntity,
+      this.abortController.signal
+    )
     if (!this.abortController.signal.aborted) {
-      this.setState({ preview });
+      this.setState({
+        preview: preview,
+        title: title
+      });
     }
+    console.log(title) // for development
   }
 
   componentWillUnmount() {
@@ -174,7 +184,7 @@ export default class LinkView
         }}
       >
         <div className="twohop-links-box-title">
-          {removeBlockReference(this.props.fileEntity.linkText)}
+          {this.state.title}
         </div>
         <div className={"twohop-links-box-preview"}>
           {this.state.preview &&

--- a/src/ui/LinkView.tsx
+++ b/src/ui/LinkView.tsx
@@ -56,7 +56,6 @@ export default class LinkView
         title: title
       });
     }
-    console.log(title) // for development
   }
 
   componentWillUnmount() {

--- a/src/ui/LinkView.tsx
+++ b/src/ui/LinkView.tsx
@@ -8,6 +8,7 @@ interface LinkViewProps {
   fileEntity: FileEntity;
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity, signal: AbortSignal) => Promise<string>;
+  getTitle: (fileEntity: FileEntity, signal: AbortSignal) => Promise<string>;
   app: App;
 }
 

--- a/src/ui/NewLinksView.tsx
+++ b/src/ui/NewLinksView.tsx
@@ -8,6 +8,7 @@ interface NewLinksViewProps {
   displayedBoxCount: number;
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   onLoadMore: () => void;
   app: App;
 }
@@ -55,6 +56,7 @@ export default class NewLinksView extends React.Component<NewLinksViewProps> {
                   key={it.key()}
                   onClick={this.props.onClick}
                   getPreview={this.props.getPreview}
+                  getTitle={this.props.getTitle}
                   app={this.props.app}
                 />
               );

--- a/src/ui/TagLinksListView.tsx
+++ b/src/ui/TagLinksListView.tsx
@@ -8,6 +8,7 @@ interface PropertiesLinksListViewProps {
   propertiesLinksList: PropertiesLinks[];
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   app: App;
   displayedSectionCount: number;
   initialDisplayedEntitiesCount: number;
@@ -18,6 +19,7 @@ interface LinkComponentProps {
   tagLink: PropertiesLinks;
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   app: App;
   initialDisplayedEntitiesCount: number;
   resetDisplayedEntitiesCount: boolean;
@@ -90,6 +92,7 @@ const LinkComponent = React.memo(
                 key={this.props.tagLink.property + it.key() + index}
                 onClick={this.props.onClick}
                 getPreview={this.props.getPreview}
+                getTitle={this.props.getTitle}
                 app={this.props.app}
               />
             ))}
@@ -120,6 +123,7 @@ const PropertiesLinksListView = React.memo(
                 tagLink={tagLink}
                 onClick={this.props.onClick}
                 getPreview={this.props.getPreview}
+                getTitle={this.props.getTitle}
                 app={this.props.app}
                 initialDisplayedEntitiesCount={
                   this.props.initialDisplayedEntitiesCount

--- a/src/ui/TwohopLinksRootView.tsx
+++ b/src/ui/TwohopLinksRootView.tsx
@@ -17,6 +17,7 @@ interface TwohopLinksRootViewProps {
   frontmatterKeyLinksList: PropertiesLinks[];
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   app: App;
   showForwardConnectedLinks: boolean;
   showBackwardConnectedLinks: boolean;
@@ -184,6 +185,7 @@ export default class TwohopLinksRootView extends React.Component<
             }
             onClick={this.props.onClick}
             getPreview={this.props.getPreview}
+            getTitle={this.props.getTitle}
             onLoadMore={() => this.loadMoreBox("forwardConnectedLinks")}
             title={"Links"}
             className={"twohop-links-forward-links"}
@@ -198,6 +200,7 @@ export default class TwohopLinksRootView extends React.Component<
             }
             onClick={this.props.onClick}
             getPreview={this.props.getPreview}
+            getTitle={this.props.getTitle}
             onLoadMore={() => this.loadMoreBox("backwardConnectedLinks")}
             title={"Back Links"}
             className={"twohop-links-back-links"}
@@ -209,6 +212,7 @@ export default class TwohopLinksRootView extends React.Component<
             twoHopLinks={this.props.twoHopLinks}
             onClick={this.props.onClick}
             getPreview={this.props.getPreview}
+            getTitle={this.props.getTitle}
             app={this.props.app}
             displayedSectionCount={this.state.displayedSectionCount.twoHopLinks}
             initialDisplayedEntitiesCount={this.props.initialBoxCount}
@@ -231,6 +235,7 @@ export default class TwohopLinksRootView extends React.Component<
             displayedBoxCount={this.state.displayedBoxCount.newLinks}
             onClick={this.props.onClick}
             getPreview={this.props.getPreview}
+            getTitle={this.props.getTitle}
             onLoadMore={() => this.loadMoreBox("newLinks")}
             app={this.props.app}
           />
@@ -240,6 +245,7 @@ export default class TwohopLinksRootView extends React.Component<
             propertiesLinksList={this.props.tagLinksList}
             onClick={this.props.onClick}
             getPreview={this.props.getPreview}
+            getTitle={this.props.getTitle}
             app={this.props.app}
             displayedSectionCount={
               this.state.displayedSectionCount.tagLinksList
@@ -263,6 +269,7 @@ export default class TwohopLinksRootView extends React.Component<
             propertiesLinksList={this.props.frontmatterKeyLinksList}
             onClick={this.props.onClick}
             getPreview={this.props.getPreview}
+            getTitle={this.props.getTitle}
             app={this.props.app}
             displayedSectionCount={
               this.state.displayedSectionCount.frontmatterKeyLinksList

--- a/src/ui/TwohopLinksView.tsx
+++ b/src/ui/TwohopLinksView.tsx
@@ -5,6 +5,7 @@ import { TwohopLink } from "../model/TwohopLink";
 import { App, setIcon } from "obsidian";
 
 interface TwohopLinksViewProps {
+  
   twoHopLinks: TwohopLink[];
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
@@ -27,6 +28,7 @@ interface LinkComponentProps {
 
 interface LinkComponentState {
   displayedEntitiesCount: number;
+  title: string;
 }
 
 class LinkComponent extends React.Component<
@@ -39,13 +41,20 @@ class LinkComponent extends React.Component<
     super(props);
     this.state = {
       displayedEntitiesCount: props.initialDisplayedEntitiesCount,
+      title: null
     };
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (this.loadMoreRef.current) {
       setIcon(this.loadMoreRef.current, "more-horizontal");
     }
+
+    const title = await this.props.getTitle(this.props.link.link)
+
+    this.setState({
+      title: title
+    });
   }
 
   componentDidUpdate(prevProps: LinkComponentProps) {
@@ -85,7 +94,7 @@ class LinkComponent extends React.Component<
             event.button == 0 && this.props.onClick(this.props.link.link)
           }
         >
-          {this.props.link.link.linkText.replace(/\.md$/, "")}
+          {this.state.title}
         </div>
         {this.props.link.fileEntities
           .slice(0, this.state.displayedEntitiesCount)
@@ -126,6 +135,7 @@ class TwohopLinksView extends React.Component<TwohopLinksViewProps> {
               link={link}
               onClick={this.props.onClick}
               getPreview={this.props.getPreview}
+              getTitle={this.props.getTitle}
               app={this.props.app}
               initialDisplayedEntitiesCount={
                 this.props.initialDisplayedEntitiesCount

--- a/src/ui/TwohopLinksView.tsx
+++ b/src/ui/TwohopLinksView.tsx
@@ -8,6 +8,7 @@ interface TwohopLinksViewProps {
   twoHopLinks: TwohopLink[];
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   app: App;
   displayedSectionCount: number;
   initialDisplayedEntitiesCount: number;
@@ -18,6 +19,7 @@ interface LinkComponentProps {
   link: TwohopLink;
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
+  getTitle: (fileEntity: FileEntity) => Promise<string>;
   app: App;
   initialDisplayedEntitiesCount: number;
   resetDisplayedEntitiesCount: boolean;
@@ -93,6 +95,7 @@ class LinkComponent extends React.Component<
               key={this.props.link.link.linkText + it.key()}
               onClick={this.props.onClick}
               getPreview={this.props.getPreview}
+              getTitle={this.props.getTitle}
               app={this.props.app}
             />
           ))}


### PR DESCRIPTION
Issue [#14](https://github.com/L7Cy/obsidian-2hop-links-plus/issues/14)に基づいて、2つの機能を実装しました：

1. frontmatterのプロパティを設定する新しいフィールド。
2. 適切なタイトルを取得するgetTitle関数。

TwohopSettingTab.tsにおいて、新たにcreateTextSettingStr()関数を作成しました。
元のcreateTextSetting()関数は数値型しか受け入れていなかったので、String型を受け入れるこの新しい関数を作成しました。元のcreateTextSetting()関数は残しましたが、今後の開発で混乱を避けるために、createTextSetting()をcreateTextSettingNum()やcreateTextSettingNumber()などに名前を変更することを提案します。
お時間のある時にご確認と検討をお願いいたします。ありがとうございます！