### PR TITLE
Fixed unexpected mouse event behavior

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,28 @@
 MIT License
 
+Copyright (c) 2025 KenInCan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Here is the opyright notice for Obsidian 2Hop Links Plus Plugin where this
+repo is forked from:
+
 Copyright (c) 2023 L7Cy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
-# Obsidian 2Hop Links Plus
+# Obsidian 2Hop Links Plus Fix
 
-2Hop Links Plus is an [Obsidian](https://obsidian.md/) plugin that displays related links up to 2 hops away in a card format. This makes it easy to browse the connections between notes. Each card contains a preview of the corresponding note.
+2Hop Links Plus Fix is an [Obsidian](https://obsidian.md/) plugin that displays related links up to 2 hops away in a card format. This makes it easy to browse the connections between notes. Each card contains a preview of the corresponding note.
 
 [![Image from Gyazo](https://i.gyazo.com/bf49c9e6314b4141215fd6f627e80da1.png)](https://gyazo.com/bf49c9e6314b4141215fd6f627e80da1)
 [![Image from Gyazo](https://i.gyazo.com/4947e25e5963b6d22b748ed3204b57b2.png)](https://gyazo.com/4947e25e5963b6d22b748ed3204b57b2)
 
 > **Note**
-> This plugin is a fork of [tokuhirom/obsidian-2hop-links-plugin](https://github.com/tokuhirom/obsidian-2hop-links-plugin) and extends its functionality.
->
+> This plugin is a fork of [rokuhirom/obsidian-2hop-links-plugin](https://github.com/tokuhirom/obsidian-2hop-links-plugin)
+> a fork of [rokuhirom/obsidian-2hop-links-plugin](https://github.com/tokuhirom/obsidian-2hop-links-plugin)
+> which is a fork of the original repo: [rokuhirom/obsidian-2hop-links-plugin](https://github.com/tokuhirom/obsidian-2hop-links-plugin)
 > The main additional features are as follows:
->
-> - Automatic adjustment of box width
-> - Improved preview content
-> - Support for external link images
-> - Setting of exclusion paths
-> - Context menu (e.g., open in new tab)
-> - Sort of links
-> - Display in a separate pane
+> bug fix concerning the behavior of the middle mouse button

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,10 +1,10 @@
 {
-  "id": "2hop-links-plus",
-  "name": "2Hop Links Plus",
-  "version": "0.37.0",
+  "id": "2hop-links-plus-fix",
+  "name": "2Hop Links Plus Fix",
+  "version": "0.37.1",
   "minAppVersion": "1.3.5",
   "description": "Related links up to 2 hops away are displayed in a card format, allowing for easy browsing through connections between notes. Each card contains a preview of the corresponding note.",
-  "author": "Tokuhiro Matsuno, L7Cy",
-  "authorUrl": "https://github.com/L7Cy",
+  "author": "Tokuhiro Matsuno, L7Cy, KenInCan",
+  "authorUrl": "https://github.com/KenInCan",
   "isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "2hop-links-plus",
-  "name": "2Hop Links Plus",
-  "version": "0.37.0",
+  "id": "2hop-links-plus-fix",
+  "name": "2Hop Links Plus Fix",
+  "version": "0.37.1",
   "minAppVersion": "1.3.5",
   "description": "Related links up to 2 hops away are displayed in a card format, allowing for easy browsing through connections between notes. Each card contains a preview of the corresponding note.",
-  "author": "Tokuhiro Matsuno, L7Cy",
-  "authorUrl": "https://github.com/L7Cy",
+  "author": "Tokuhiro Matsuno, L7Cy, KenInCan",
+  "authorUrl": "https://github.com/KenInCan",
   "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2hop-links-plus",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Related links up to 2 hops away are displayed in a card format, allowing for easy browsing through connections between notes. Each card contains a preview of the corresponding note.",
   "main": "main.js",
   "scripts": {

--- a/src/ui/LinkView.tsx
+++ b/src/ui/LinkView.tsx
@@ -162,6 +162,9 @@ export default class LinkView
           if (event.button === 0) {
             this.setState({ mouseDown: true });
           }
+          if (event.button === 1) {
+            event.preventDefault();
+          }
         }}
         onMouseUp={(event) => {
           if (this.isMobile) return;

--- a/src/ui/TwohopLinksView.tsx
+++ b/src/ui/TwohopLinksView.tsx
@@ -5,7 +5,6 @@ import { TwohopLink } from "../model/TwohopLink";
 import { App, setIcon } from "obsidian";
 
 interface TwohopLinksViewProps {
-  
   twoHopLinks: TwohopLink[];
   onClick: (fileEntity: FileEntity) => Promise<void>;
   getPreview: (fileEntity: FileEntity) => Promise<string>;
@@ -90,9 +89,6 @@ class LinkComponent extends React.Component<
         <div
           className={"twohop-links-twohop-header twohop-links-box"}
           onClick={async () => this.props.onClick(this.props.link.link)}
-          onMouseDown={async (event) =>
-            event.button == 0 && this.props.onClick(this.props.link.link)
-          }
         >
           {this.state.title}
         </div>


### PR DESCRIPTION
Hi, This addresses two mouse event behavior that is probably unexpected.

## Middle-clicking a card will lock the mouse cursor in auto-scrolling mode.
If you middle-click on a card, the page opens in a new tab. But the cursor goes into auto-scrolling mode.
It cannot be reverted to normal cursor unless you go to the original page where you middle clicked and 
middle clicking somewhere.

This is addressed in the first commit, by calling event.preventDefault function if it was the middle mouse button.

![first-issue](https://github.com/user-attachments/assets/326c7548-3cc5-4a7a-b43b-ae59193400bd)


## When left-clicking the TwohopLink header, it will hop twice in a single click if the conditions are met.
When I click the TwohopLink header to test2.md, the test3.md opens.
This is because the test2.md is opened with the onMouseDown event, after that test3.md is opend with the onMouseUp event.
This issue only arises if the cursor aligns with the card when the onMouseUp event is fired.

This is addressed in the second commit, by removing the onMouseDown event from the twohop-links-twohop-header div. Since the file will open with the onClick event, its probably redundant.

![second-issue](https://github.com/user-attachments/assets/bc08ca3b-3a81-4f2d-9963-006fc09f97df)

