### PR TITLE
Upgrade obsidian types to ^1.12.3 to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@types/react": "^17.0.3",
     "@types/react-dom": "17.0.2",
-    "obsidian": "obsidianmd/obsidian-api#master",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "tslib": "2.2.0"
@@ -26,11 +25,11 @@
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "builtin-modules": "3.3.0",
+    "esbuild": "0.14.47",
     "eslint": "^7.25.0",
-    "obsidian": "^0.12.0",
+    "obsidian": "^1.12.3",
     "prettier": "^2.3.0",
     "tslib": "^2.2.0",
-    "esbuild": "0.14.47",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
## Summary

`npm run build` fails on a clean `master` checkout with 4 TypeScript errors because the `obsidian` devDependency is pinned at `^0.12.0` (resolved to 0.12.17), while the source already uses APIs introduced in later versions:

```
src/links.ts(111,25): error TS2551: Property 'frontmatterLinks' does not exist on type 'CachedMetadata'.
src/links.ts(117,29): error TS2551: Property 'frontmatterLinks' does not exist on type 'CachedMetadata'.
src/ui/LinkView.tsx(72,34): error TS2345: Argument of type 'string' is not assignable to parameter of type 'boolean'.
src/ui/LinkView.tsx(90,18): error TS2554: Expected 1 arguments, but got 0.
```

- `CachedMetadata.frontmatterLinks` was added later.
- `Workspace.getLeaf(PaneType | boolean)` widened its argument type (the old `0.12` signature was `(newLeaf?: boolean)` only).
- `new Menu()` no longer takes a required argument.

Bumping the dev dependency to the current `obsidian@1.12.3` types resolves all four errors without touching any call site. Also dropped the redundant `"obsidian": "obsidianmd/obsidian-api#master"` entry from `dependencies` — the devDependency already supplies the same types, and the GitHub tarball reference is just legacy noise.

## Test plan

- [x] `npm install` succeeds
- [x] `npm run build` succeeds and produces `main.js` (~924kb)
- [x] No source files needed to change

Happy to follow up with a `minAppVersion` bump and CI Node.js refresh in a separate PR if useful.